### PR TITLE
add bind_ip to better listen IP control

### DIFF
--- a/src/httpServer.js
+++ b/src/httpServer.js
@@ -847,5 +847,5 @@ exports.initServer = (state, cb) => {
 		}
 	});
 
-	app.listen(state.config.port, cb);
+	app.listen(state.config.port, state.config.bind_ip);
 };

--- a/src/server.js
+++ b/src/server.js
@@ -12,6 +12,7 @@ function main() {
 		const state = {
 			config: {
 				port: server_config.webserver_port || 3000,
+				bind_ip: '127.0.0.1',
 				devLogs: false
 			},
 			server_config: null

--- a/src/server.js
+++ b/src/server.js
@@ -12,6 +12,7 @@ function main() {
 		const state = {
 			config: {
 				port: server_config.webserver_port || 3000,
+				bind_ip: '127.0.0.1' ,
 				devLogs: false
 			},
 			server_config: null


### PR DESCRIPTION
In my opinion, this small change will help Pro users gain more control over server ports, and users who like to restrict the application via IPTABLES or firewall or make the Reverse Proxy for this application have  more options and are easier to reassure.